### PR TITLE
Point people to the GitHub Education Community

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,3 @@
-This discussion space has moved to the new [GitHub Education Community](https://education.github.community)
+This discussion space has moved to the [GitHub Education Community](https://education.github.community)
 
 Rather than opening a new issue here, please [open a new topic](https://education.github.community/new-topic) in the community forum.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+This discussion space has moved to the new [GitHub Education Community](https://education.github.community)
+
+Rather than opening a new issue here, please [open a new topic](https://education.github.community/new-topic) in the community forum.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### This discussion space has moved to the new [GitHub Education Community](https://education.github.community).
+### This discussion space has moved to the [GitHub Education Community](https://education.github.community).
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This discussion space has moved to the new [GitHub Education Community](https://education.github.community).
+
+----
+
 # GitHub's teacher community
 
 Welcome to the teacher community on GitHub, a collaborative space for sharing ideas around using GitHub in learning environments.


### PR DESCRIPTION
This updates the `README` and `ISSUE_TEMPLATE.md` to point people to the new [GitHub Education Community](https://education.github.community)

cc/ @sanicki 
